### PR TITLE
Include MCP route in Headcode registry

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -226,6 +226,11 @@
           "target": "app/llms.txt/route.ts"
         },
         {
+          "path": "app/(mcp)/[transport]/route.ts",
+          "type": "registry:file",
+          "target": "app/(mcp)/[transport]/route.ts"
+        },
+        {
           "path": "app/sitemap.ts",
           "type": "registry:file",
           "target": "app/sitemap.ts"


### PR DESCRIPTION
## Summary
- add `app/(mcp)/[transport]/route.ts` to the shadcn registry item
- fixes fresh installs receiving MCP docs/dependency but not the MCP route handler

## Check
- pnpm dlx shadcn@latest registry validate

## Notes
The installed endpoint is `/mcp`; `(mcp)` is a Next.js route group and `[transport]` captures the `mcp` path segment.
